### PR TITLE
expect not to create a book if invalid

### DIFF
--- a/content/architecture/interactors.md
+++ b/content/architecture/interactors.md
@@ -555,7 +555,7 @@ RSpec.describe Web::Controllers::Books::Create do
     let(:params) { Hash[book: {}] }
 
     it 'calls interactor' do
-      expect(interactor).to receive(:call)
+      expect(interactor).to_not receive(:call)
       response = action.call(params)
     end
 


### PR DESCRIPTION
When `params` are not valid, we won't expect to call the `AddBook` interactor. 
Change spec to match this.